### PR TITLE
Update `ftp.ncbi.nih.gov` => `ftp.ncbi.nlm.nih.gov`

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -5,10 +5,10 @@ download: download-taxdump download-accession-to-taxid
 
 download-taxdump:
 	@echo 'Downloading new_taxdump.tar.gz'
-	curl -O -L 'ftp://ftp.ncbi.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz'
+	curl -O -L 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz'
 	@echo 'Untarring new_taxdump.tar.gz'
 	tar xfz new_taxdump.tar.gz
 
 download-accession-to-taxid:
 	@echo 'Downloading nucl_gb.accession2taxid.gz (be patient)'
-	curl -O -L 'ftp://ftp.ncbi.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz'
+	curl -O -L 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz'


### PR DESCRIPTION
Fixes #4 

Hello,

I suggest changing this domain name because they both point to the exact same location, but one is recognized by DNS servers worldwide, while the other is not.

<img width="891" alt="Screenshot 2024-03-19 at 15 58 22" src="https://github.com/acorg/ncbi-taxonomy-database/assets/33789758/3de981c2-9ab0-479a-9387-532edd4bfe83">

<img width="889" alt="Screenshot 2024-03-19 at 15 58 38" src="https://github.com/acorg/ncbi-taxonomy-database/assets/33789758/978ef7d0-6475-4fb3-83ad-950e97c26427">

<img width="904" alt="image" src="https://github.com/acorg/ncbi-taxonomy-database/assets/33789758/ba9617e0-416f-4d94-8632-9671c915a0fe">
also as you can see they are alias, but is not avaliable on all dns servers.

<img width="585" alt="Screenshot 2024-03-19 at 15 59 52" src="https://github.com/acorg/ncbi-taxonomy-database/assets/33789758/6aec2eb8-b51e-45a0-ae54-ce1ce47a8b00">


<img width="597" alt="Screenshot 2024-03-19 at 16 00 12" src="https://github.com/acorg/ncbi-taxonomy-database/assets/33789758/3d0fd066-4219-4e2b-92b3-ae9ed4327dc2">
