### PR TITLE
change download url protocol ftp -> https

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -5,10 +5,10 @@ download: download-taxdump download-accession-to-taxid
 
 download-taxdump:
 	@echo 'Downloading new_taxdump.tar.gz'
-	curl -O -L 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz'
+	curl -O -L 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz'
 	@echo 'Untarring new_taxdump.tar.gz'
 	tar xfz new_taxdump.tar.gz
 
 download-accession-to-taxid:
 	@echo 'Downloading nucl_gb.accession2taxid.gz (be patient)'
-	curl -O -L 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz'
+	curl -O -L 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz'


### PR DESCRIPTION
For the last few months, FTP download speeds have been quite low; instead, the HTTPS protocol serves these files much faster. You can see the comparison between FTP and HTTPS in the screenshots below.

FTP
![Screenshot 2024-10-11 at 14 49 06](https://github.com/user-attachments/assets/6b802401-4e84-4e23-850d-0d17e3303e10)


HTTPS
![Screenshot 2024-10-11 at 14 49 10](https://github.com/user-attachments/assets/8a466640-4529-4cae-9045-45afe277d750)

